### PR TITLE
Avoid top-of-hour schedule congestion

### DIFF
--- a/.github/workflows/build_scheduled.yml
+++ b/.github/workflows/build_scheduled.yml
@@ -3,7 +3,7 @@ name: 'build scheduled'
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *" # every 12 hours
+    - cron: "17 */12 * * *" # every 12 hours, away from top-of-hour load
 
 jobs:
   get_links_json:


### PR DESCRIPTION
## What changed

- move the scheduled Bedrock version check from minute `0` to minute `17`
- keep the existing 12-hour cadence

## Why

GitHub documents that scheduled workflows can be delayed or dropped during high load at the start of an hour. The repository's scheduled workflow stopped running reliably, and re-enabling it during the August 6 Actions incident did not restore dependable scheduled triggers.

Committing the cron change also causes GitHub to register the updated schedule on the default branch once merged.

## Validation

- `git diff --check`
- workflow YAML parsed successfully with Ruby/Psych
- confirmed the only diff is `.github/workflows/build_scheduled.yml`
